### PR TITLE
Upgrade to latest Elixir and use mirego/formex as dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  ci:
+    name: Run tests (Elixir ${{matrix.elixir}}, OTP ${{matrix.otp}})
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        include:
+          - elixir: '1.13'
+            otp: '23.3'
+          - elixir: '1.14'
+            otp: '25'
+            lint: lint
+
+    env:
+      MIX_ENV: test
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
+
+      - name: Restore deps and _build cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            deps
+            _build
+          key: deps-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            deps-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}
+      - name: Install dependencies
+        run: mix deps.get --only test
+
+      - name: Check source code format
+        run: mix format --check-formatted
+        if: ${{ matrix.lint }}
+
+      - name: Remove compiled application files
+        run: mix clean
+
+      - name: Compile dependencies
+        run: mix compile
+        if: ${{ !matrix.lint }}
+
+      - name: Compile & lint dependencies
+        run: mix compile --warnings-as-errors && mix credo
+        if: ${{ matrix.lint }}
+
+      - name: Run tests
+        run: mix test

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 25.1.1
+elixir 1.14.1-otp-25

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 if Mix.env() == :test do
   import_config "test.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :formex,
   validator: Formex.Validator.Vex,

--- a/lib/formex_vex.ex
+++ b/lib/formex_vex.ex
@@ -4,17 +4,6 @@ defmodule Formex.Validator.Vex do
 
   @spec validate(Form.t()) :: Form.t()
   def validate(form) do
-    # errors_struct = if form.type.validate_whole_struct? do
-    #   form.new_struct
-    #   |> Vex.errors
-    #   |> Enum.reduce([], fn error ->
-    #     IO.inspect error
-
-    #   end)
-    # else
-    #   []
-    # end
-
     errors_type =
       form
       |> Form.get_fields_validatable()

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Formex.Validator.Vex.Mixfile do
     [
       app: :formex_vex,
       version: "0.1.1",
-      elixir: "~> 1.3",
+      elixir: "~> 1.14",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -23,13 +23,14 @@ defmodule Formex.Validator.Vex.Mixfile do
 
   defp deps do
     deps = [
-      {:vex, "~> 0.6.0"},
+      {:plug, "~> 1.14"},
+      {:vex, "~> 0.9"},
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:credo, "~> 0.9", only: [:dev, :test], runtime: false}
+      {:credo, "~> 1.0", only: [:dev, :test], runtime: false}
     ]
 
     if !System.get_env("FORMEX_DEV") do
-      deps ++ [{:formex, ">= 0.5.0 and < 0.7.0"}]
+      deps ++ [{:formex, github: "mirego/formex"}]
     else
       deps
     end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Formex.Validator.Vex.Mixfile do
     [
       app: :formex_vex,
       version: "0.1.1",
-      elixir: "~> 1.14",
+      elixir: "~> 1.13",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/formex_vex/formex_vex_test.exs
+++ b/test/formex_vex/formex_vex_test.exs
@@ -2,9 +2,6 @@ defmodule Formex.Validator.Vex.Test.UserType do
   use Formex.Type
 
   def build_form(form) do
-    # |> add(:age, validation: [
-    #   presence: :true
-    # ])
     form
     |> add(
       :first_name,


### PR DESCRIPTION
Dans la suite d'updates des forks relatifs à `formex`, on fork et upgrade `formex_vex` afin d'utiliser le fork `mirego/formex`. 